### PR TITLE
fix(s.weibo.com): fix navigator and logo color for dynamic mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19441,6 +19441,19 @@ INVERT
 
 ================================
 
+s.weibo.com
+
+CSS
+[data-darkreader-inline-bgcolor] {
+    --darkreader-bg--weibo-top-nav-panel-bgColor: rgb(24, 26, 27);
+    --darkreader-border--weibo-top-nav-panel-bd: rgb(52, 56, 58);
+}
+#woo_svg_nav_logo > g > path:nth-child(5) {
+    fill: rgb(6, 1, 1) !important;
+}
+
+================================
+
 sadanduseless.com
 
 INVERT


### PR DESCRIPTION
before:
![image](https://github.com/Asukaaaaaa/darkreader/assets/24503369/bccd53bb-ee0d-4931-9382-57cb84ced662)

after:
![image](https://github.com/Asukaaaaaa/darkreader/assets/24503369/e7395a0e-ff52-40c9-b2aa-54f30e25e5b3)
